### PR TITLE
UI Tweaks

### DIFF
--- a/Util POC/Util POC.xcodeproj/project.pbxproj
+++ b/Util POC/Util POC.xcodeproj/project.pbxproj
@@ -521,10 +521,10 @@
 				INFOPLIST_FILE = "Util POC/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.deloitte.pushsample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.deloitte.util;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "a9ebc497-025b-46f4-a12c-81f5a3799d78";
-				PROVISIONING_PROFILE_SPECIFIER = "Push Sample App Certificate";
+				PROVISIONING_PROFILE = "96582d9c-b38c-402f-99d2-5f0772640461";
+				PROVISIONING_PROFILE_SPECIFIER = "UTIL profile";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -537,10 +537,10 @@
 				INFOPLIST_FILE = "Util POC/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.deloitte.pushsample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.deloitte.util;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "a9ebc497-025b-46f4-a12c-81f5a3799d78";
-				PROVISIONING_PROFILE_SPECIFIER = "Push Sample App Certificate";
+				PROVISIONING_PROFILE = "96582d9c-b38c-402f-99d2-5f0772640461";
+				PROVISIONING_PROFILE_SPECIFIER = "UTIL profile";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/Util POC/Util POC.xcodeproj/project.pbxproj
+++ b/Util POC/Util POC.xcodeproj/project.pbxproj
@@ -539,7 +539,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deloitte.util;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "96582d9c-b38c-402f-99d2-5f0772640461";
+				PROVISIONING_PROFILE = "0b037500-46f0-4182-a3ab-f50ad6cb5c0e";
 				PROVISIONING_PROFILE_SPECIFIER = "UTIL profile";
 				SWIFT_VERSION = 3.0;
 			};

--- a/Util POC/Util POC/Base.lproj/Main.storyboard
+++ b/Util POC/Util POC/Base.lproj/Main.storyboard
@@ -208,21 +208,21 @@
                                                     </constraints>
                                                 </imageView>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="oGU-ZO-zKd">
-                                                    <rect key="frame" x="0.0" y="213" width="339" height="1"/>
+                                                    <rect key="frame" x="0.0" y="219" width="339" height="1"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="0q9-c8-x44"/>
                                                     </constraints>
                                                 </imageView>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NhF-Qk-YrI">
-                                                    <rect key="frame" x="0.0" y="273.5" width="339" height="1"/>
+                                                    <rect key="frame" x="0.0" y="281.5" width="339" height="1"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="3Cx-DL-6bp"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VWS-Wa-RN0">
-                                                    <rect key="frame" x="216" y="31" width="91" height="21"/>
+                                                    <rect key="frame" x="216" y="31" width="91" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="91" id="Qtf-WF-4UI"/>
                                                     </constraints>
@@ -243,7 +243,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Electricity services" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zEt-WQ-5wo">
-                                                    <rect key="frame" x="71" y="56" width="236" height="14"/>
+                                                    <rect key="frame" x="71" y="56" width="236" height="16"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="236" id="Fen-4j-FxZ"/>
                                                     </constraints>
@@ -252,7 +252,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Consumption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lFI-pz-Qlf">
-                                                    <rect key="frame" x="31" y="237" width="144" height="16.5"/>
+                                                    <rect key="frame" x="31" y="243" width="144" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="y0z-zZ-oj5"/>
                                                     </constraints>
@@ -261,7 +261,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H81-xQ-zpa">
-                                                    <rect key="frame" x="31" y="294.5" width="144" height="16.5"/>
+                                                    <rect key="frame" x="31" y="302.5" width="144" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="2W8-80-ulF"/>
                                                     </constraints>
@@ -270,7 +270,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="643Kwh" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHg-TT-amX">
-                                                    <rect key="frame" x="216" y="233" width="103" height="21"/>
+                                                    <rect key="frame" x="216" y="239" width="103" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="103" id="0My-4P-f88"/>
                                                     </constraints>
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqV-hD-OHN">
-                                                    <rect key="frame" x="216" y="285.5" width="80" height="30.5"/>
+                                                    <rect key="frame" x="216" y="293.5" width="80" height="34.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="80" id="dTk-Qk-GGC"/>
                                                     </constraints>
@@ -288,7 +288,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pkm-lW-Jee">
-                                                    <rect key="frame" x="86" y="329" width="168" height="31"/>
+                                                    <rect key="frame" x="86" y="339" width="168" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="Xcd-zK-h1z"/>
                                                         <constraint firstAttribute="width" constant="168" id="b4n-Yb-9iH"/>
@@ -301,7 +301,7 @@
                                                     </state>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Billing Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oFl-m3-wD2">
-                                                    <rect key="frame" x="31" y="139" width="113" height="16.5"/>
+                                                    <rect key="frame" x="31" y="139" width="113" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="113" id="cve-jR-AoV"/>
                                                     </constraints>
@@ -309,8 +309,8 @@
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3275NW 24thStreet Rd, Miami" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbj-x7-GU4">
-                                                    <rect key="frame" x="31" y="160" width="160" height="33"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3275NW 24thStreet Rd, Tampa" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbj-x7-GU4">
+                                                    <rect key="frame" x="31" y="162" width="160" height="37"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="M2l-0T-opr"/>
                                                         <constraint firstAttribute="width" constant="160" id="X0w-N4-Hxf"/>
@@ -387,7 +387,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TOTAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vRT-mJ-awv">
-                                            <rect key="frame" x="147.5" y="8" width="80" height="16.5"/>
+                                            <rect key="frame" x="147.5" y="8" width="80" height="18.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="80" id="DQT-CC-RPm"/>
                                             </constraints>
@@ -396,7 +396,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LWA-ya-DgH">
-                                            <rect key="frame" x="147.5" y="32" width="80.5" height="32"/>
+                                            <rect key="frame" x="146.5" y="34" width="83" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="bg5-Ta-Wnl"/>
                                             </constraints>
@@ -405,7 +405,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z3N-kf-Rw8">
-                                            <rect key="frame" x="118.5" y="81" width="138" height="40"/>
+                                            <rect key="frame" x="118.5" y="83" width="138" height="40"/>
                                             <color key="backgroundColor" red="0.98039215690000003" green="0.1960784314" blue="0.32156862749999998" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="138" id="Rjf-of-c6f"/>
@@ -540,7 +540,7 @@
                                                                 <constraint firstAttribute="height" constant="1" id="YXN-Qe-9k5"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3275NW 24thStreet Rd, Miami" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3cg-Rr-hIn">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3275NW 24thStreet Rd, Tampa" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3cg-Rr-hIn">
                                                             <rect key="frame" x="40" y="104" width="156" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="FsP-ws-msL"/>
@@ -883,7 +883,7 @@
                                                             <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.12$/kwh" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P5n-CK-AIB">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$0.12/kwh" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P5n-CK-AIB">
                                                             <rect key="frame" x="206.5" y="88" width="93" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="93" id="WsK-I5-gfy"/>
@@ -994,7 +994,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4o7-p1-Dhm">
-                                                    <rect key="frame" x="146.5" y="33.5" width="83" height="32"/>
+                                                    <rect key="frame" x="146" y="33.5" width="83" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="B8P-Jl-IQG"/>
                                                     </constraints>
@@ -1824,13 +1824,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Account Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wa2-No-9g0">
-                                        <rect key="frame" x="35" y="18.5" width="122" height="19"/>
+                                        <rect key="frame" x="35" y="17.5" width="121" height="21.5"/>
                                         <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="16"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5742235647" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4rs-2f-K4V">
-                                        <rect key="frame" x="251" y="19" width="89" height="19"/>
+                                        <rect key="frame" x="248" y="17" width="92" height="21.5"/>
                                         <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="16"/>
                                         <color key="textColor" red="1" green="0.84705882352941175" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1965,7 +1965,7 @@
                                         </constraints>
                                         <string key="text">3275 NW 24th Street Rd,
 242353,
-Miami FL</string>
+Tampa FL</string>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                         <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -2200,7 +2200,7 @@ Miami FL</string>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oGG-Jl-CHl">
-                                                    <rect key="frame" x="216" y="31" width="91" height="21"/>
+                                                    <rect key="frame" x="216" y="31" width="91" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="91" id="T3Q-ak-DKn"/>
                                                     </constraints>
@@ -2221,7 +2221,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Electricity services" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iNc-zw-zHK">
-                                                    <rect key="frame" x="71" y="56" width="236" height="14"/>
+                                                    <rect key="frame" x="71" y="56" width="236" height="16"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="236" id="Z2Z-zM-GST"/>
                                                     </constraints>
@@ -2230,7 +2230,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Consumption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zgW-n1-k2A">
-                                                    <rect key="frame" x="31" y="123" width="144" height="16.5"/>
+                                                    <rect key="frame" x="31" y="123" width="144" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="y3l-Wy-pjC"/>
                                                     </constraints>
@@ -2239,7 +2239,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gns-9N-7Jk">
-                                                    <rect key="frame" x="31" y="190" width="144" height="16.5"/>
+                                                    <rect key="frame" x="31" y="190" width="144" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="OtQ-LR-Rdh"/>
                                                     </constraints>
@@ -2248,7 +2248,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="643Kwh" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="enr-Bt-uWD">
-                                                    <rect key="frame" x="216" y="119" width="103" height="21"/>
+                                                    <rect key="frame" x="216" y="119" width="103" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="103" id="cnO-SN-ul2"/>
                                                     </constraints>
@@ -2257,7 +2257,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I0U-We-o5w">
-                                                    <rect key="frame" x="216" y="181" width="80" height="30.5"/>
+                                                    <rect key="frame" x="216" y="181" width="80" height="34.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="80" id="5LQ-Hc-18e"/>
                                                     </constraints>
@@ -2266,7 +2266,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bzW-9c-ucr">
-                                                    <rect key="frame" x="86" y="266.5" width="168" height="31"/>
+                                                    <rect key="frame" x="86" y="268.5" width="168" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="168" id="PxU-zB-W7b"/>
                                                         <constraint firstAttribute="height" constant="31" id="Y5O-ht-a9h"/>
@@ -2340,7 +2340,7 @@ Miami FL</string>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TOTAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zuI-c9-srP">
-                                            <rect key="frame" x="148" y="8" width="80" height="16.5"/>
+                                            <rect key="frame" x="148" y="8" width="80" height="18.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="80" id="h7e-gE-i7r"/>
                                             </constraints>
@@ -2349,7 +2349,7 @@ Miami FL</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0gy-bu-I1g">
-                                            <rect key="frame" x="147.5" y="31.5" width="80.5" height="32"/>
+                                            <rect key="frame" x="146.5" y="33.5" width="83" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="aD6-nc-qhC"/>
                                             </constraints>
@@ -2358,7 +2358,7 @@ Miami FL</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nu3-d9-dvM">
-                                            <rect key="frame" x="119" y="80.5" width="138" height="40"/>
+                                            <rect key="frame" x="119" y="82.5" width="138" height="40"/>
                                             <color key="backgroundColor" red="0.98039215686274506" green="0.19607843137254902" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="138" id="91I-78-ygg"/>
@@ -2430,7 +2430,7 @@ Miami FL</string>
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="aZe-YR-8sg" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="2fV-ZV-dXi">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="2fV-ZV-dXi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.2196078431372549" green="0.23529411764705882" blue="0.31372549019607843" alpha="1" colorSpace="calibratedRGB"/>

--- a/Util POC/Util POC/Base.lproj/Main.storyboard
+++ b/Util POC/Util POC/Base.lproj/Main.storyboard
@@ -208,21 +208,21 @@
                                                     </constraints>
                                                 </imageView>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="oGU-ZO-zKd">
-                                                    <rect key="frame" x="0.0" y="219" width="339" height="1"/>
+                                                    <rect key="frame" x="0.0" y="213" width="339" height="1"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="0q9-c8-x44"/>
                                                     </constraints>
                                                 </imageView>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NhF-Qk-YrI">
-                                                    <rect key="frame" x="0.0" y="281.5" width="339" height="1"/>
+                                                    <rect key="frame" x="0.0" y="273.5" width="339" height="1"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="3Cx-DL-6bp"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VWS-Wa-RN0">
-                                                    <rect key="frame" x="216" y="31" width="91" height="24"/>
+                                                    <rect key="frame" x="216" y="31" width="91" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="91" id="Qtf-WF-4UI"/>
                                                     </constraints>
@@ -243,7 +243,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Electricity services" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zEt-WQ-5wo">
-                                                    <rect key="frame" x="71" y="56" width="236" height="16"/>
+                                                    <rect key="frame" x="71" y="56" width="236" height="14"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="236" id="Fen-4j-FxZ"/>
                                                     </constraints>
@@ -252,7 +252,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Consumption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lFI-pz-Qlf">
-                                                    <rect key="frame" x="31" y="243" width="144" height="18.5"/>
+                                                    <rect key="frame" x="31" y="237" width="144" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="y0z-zZ-oj5"/>
                                                     </constraints>
@@ -261,7 +261,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H81-xQ-zpa">
-                                                    <rect key="frame" x="31" y="302.5" width="144" height="18.5"/>
+                                                    <rect key="frame" x="31" y="294.5" width="144" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="2W8-80-ulF"/>
                                                     </constraints>
@@ -270,7 +270,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="643Kwh" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHg-TT-amX">
-                                                    <rect key="frame" x="216" y="239" width="103" height="24"/>
+                                                    <rect key="frame" x="216" y="233" width="103" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="103" id="0My-4P-f88"/>
                                                     </constraints>
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqV-hD-OHN">
-                                                    <rect key="frame" x="216" y="293.5" width="80" height="34.5"/>
+                                                    <rect key="frame" x="216" y="285.5" width="80" height="30.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="80" id="dTk-Qk-GGC"/>
                                                     </constraints>
@@ -288,7 +288,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pkm-lW-Jee">
-                                                    <rect key="frame" x="86" y="339" width="168" height="31"/>
+                                                    <rect key="frame" x="86" y="329" width="168" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="Xcd-zK-h1z"/>
                                                         <constraint firstAttribute="width" constant="168" id="b4n-Yb-9iH"/>
@@ -301,7 +301,7 @@
                                                     </state>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Billing Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oFl-m3-wD2">
-                                                    <rect key="frame" x="31" y="139" width="113" height="18.5"/>
+                                                    <rect key="frame" x="31" y="139" width="113" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="113" id="cve-jR-AoV"/>
                                                     </constraints>
@@ -310,7 +310,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3275NW 24thStreet Rd, Miami" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbj-x7-GU4">
-                                                    <rect key="frame" x="31" y="162" width="160" height="37"/>
+                                                    <rect key="frame" x="31" y="160" width="160" height="33"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="M2l-0T-opr"/>
                                                         <constraint firstAttribute="width" constant="160" id="X0w-N4-Hxf"/>
@@ -387,7 +387,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TOTAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vRT-mJ-awv">
-                                            <rect key="frame" x="147.5" y="8" width="80" height="18.5"/>
+                                            <rect key="frame" x="147.5" y="8" width="80" height="16.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="80" id="DQT-CC-RPm"/>
                                             </constraints>
@@ -396,7 +396,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LWA-ya-DgH">
-                                            <rect key="frame" x="146" y="34" width="83" height="32"/>
+                                            <rect key="frame" x="147.5" y="32" width="80.5" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="bg5-Ta-Wnl"/>
                                             </constraints>
@@ -405,7 +405,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z3N-kf-Rw8">
-                                            <rect key="frame" x="118.5" y="83" width="138" height="40"/>
+                                            <rect key="frame" x="118.5" y="81" width="138" height="40"/>
                                             <color key="backgroundColor" red="0.98039215690000003" green="0.1960784314" blue="0.32156862749999998" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="138" id="Rjf-of-c6f"/>
@@ -581,7 +581,7 @@
                                                             <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12/04/2017 - 12/05/2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhn-bw-9ju">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="04/12/2017 - 05/12/2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhn-bw-9ju">
                                                             <rect key="frame" x="40" y="356" width="162" height="18.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="14"/>
                                                             <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -905,7 +905,7 @@
                                                             <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23/05/2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ll3-Uj-AZf">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="05/23/2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ll3-Uj-AZf">
                                                             <rect key="frame" x="40" y="151.5" width="247" height="18.5"/>
                                                             <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="14"/>
                                                             <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -994,7 +994,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4o7-p1-Dhm">
-                                                    <rect key="frame" x="146" y="33.5" width="83" height="32"/>
+                                                    <rect key="frame" x="146.5" y="33.5" width="83" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="B8P-Jl-IQG"/>
                                                     </constraints>
@@ -1824,13 +1824,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Account Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wa2-No-9g0">
-                                        <rect key="frame" x="35" y="17" width="121" height="21.5"/>
+                                        <rect key="frame" x="35" y="18.5" width="122" height="19"/>
                                         <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="16"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5742235647" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4rs-2f-K4V">
-                                        <rect key="frame" x="248" y="17.5" width="92" height="21.5"/>
+                                        <rect key="frame" x="251" y="19" width="89" height="19"/>
                                         <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="16"/>
                                         <color key="textColor" red="1" green="0.84705882352941175" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -2200,7 +2200,7 @@ Miami FL</string>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="May 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oGG-Jl-CHl">
-                                                    <rect key="frame" x="216" y="31" width="91" height="24"/>
+                                                    <rect key="frame" x="216" y="31" width="91" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="91" id="T3Q-ak-DKn"/>
                                                     </constraints>
@@ -2221,7 +2221,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Electricity services" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iNc-zw-zHK">
-                                                    <rect key="frame" x="71" y="56" width="236" height="16"/>
+                                                    <rect key="frame" x="71" y="56" width="236" height="14"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="236" id="Z2Z-zM-GST"/>
                                                     </constraints>
@@ -2230,7 +2230,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Consumption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zgW-n1-k2A">
-                                                    <rect key="frame" x="31" y="123" width="144" height="18.5"/>
+                                                    <rect key="frame" x="31" y="123" width="144" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="y3l-Wy-pjC"/>
                                                     </constraints>
@@ -2239,7 +2239,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gns-9N-7Jk">
-                                                    <rect key="frame" x="31" y="190" width="144" height="18.5"/>
+                                                    <rect key="frame" x="31" y="190" width="144" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="144" id="OtQ-LR-Rdh"/>
                                                     </constraints>
@@ -2248,7 +2248,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="643Kwh" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="enr-Bt-uWD">
-                                                    <rect key="frame" x="216" y="119" width="103" height="24"/>
+                                                    <rect key="frame" x="216" y="119" width="103" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="103" id="cnO-SN-ul2"/>
                                                     </constraints>
@@ -2257,7 +2257,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I0U-We-o5w">
-                                                    <rect key="frame" x="216" y="181" width="80" height="34.5"/>
+                                                    <rect key="frame" x="216" y="181" width="80" height="30.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="80" id="5LQ-Hc-18e"/>
                                                     </constraints>
@@ -2266,7 +2266,7 @@ Miami FL</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bzW-9c-ucr">
-                                                    <rect key="frame" x="86" y="268.5" width="168" height="31"/>
+                                                    <rect key="frame" x="86" y="266.5" width="168" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="168" id="PxU-zB-W7b"/>
                                                         <constraint firstAttribute="height" constant="31" id="Y5O-ht-a9h"/>
@@ -2340,7 +2340,7 @@ Miami FL</string>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TOTAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zuI-c9-srP">
-                                            <rect key="frame" x="148" y="8" width="80" height="18.5"/>
+                                            <rect key="frame" x="148" y="8" width="80" height="16.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="80" id="h7e-gE-i7r"/>
                                             </constraints>
@@ -2349,7 +2349,7 @@ Miami FL</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0gy-bu-I1g">
-                                            <rect key="frame" x="146" y="33.5" width="83" height="32"/>
+                                            <rect key="frame" x="147.5" y="31.5" width="80.5" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="aD6-nc-qhC"/>
                                             </constraints>
@@ -2358,7 +2358,7 @@ Miami FL</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nu3-d9-dvM">
-                                            <rect key="frame" x="119" y="82.5" width="138" height="40"/>
+                                            <rect key="frame" x="119" y="80.5" width="138" height="40"/>
                                             <color key="backgroundColor" red="0.98039215686274506" green="0.19607843137254902" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="138" id="91I-78-ygg"/>
@@ -2430,7 +2430,7 @@ Miami FL</string>
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="aZe-YR-8sg" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="2fV-ZV-dXi">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="2fV-ZV-dXi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.2196078431372549" green="0.23529411764705882" blue="0.31372549019607843" alpha="1" colorSpace="calibratedRGB"/>

--- a/Util POC/Util POC/Base.lproj/Main.storyboard
+++ b/Util POC/Util POC/Base.lproj/Main.storyboard
@@ -1254,7 +1254,7 @@
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CDz-PJ-dEW">
                                                         <rect key="frame" x="0.0" y="90" width="375" height="90"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose Outage Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3nn-aA-cus">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose Issue Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3nn-aA-cus">
                                                                 <rect key="frame" x="30" y="0.0" width="239" height="89"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="14"/>
                                                                 <nil key="textColor"/>
@@ -1917,7 +1917,7 @@
                                         <color key="textColor" red="0.60784313729999995" green="0.60784313729999995" blue="0.60784313729999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+1(737)-7118796" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMp-i4-t5Y">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(737)-711-8796" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMp-i4-t5Y">
                                         <rect key="frame" x="34" y="182" width="150" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="150" id="HCr-Te-2y2"/>
@@ -1965,7 +1965,7 @@
                                         </constraints>
                                         <string key="text">3275 NW 24th Street Rd,
 242353,
-Tampa FL</string>
+Tampa </string>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                         <color key="textColor" red="0.28235294119999998" green="0.30588235289999999" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -2000,7 +2000,7 @@ Tampa FL</string>
                                         <color key="textColor" red="0.60784313729999995" green="0.60784313729999995" blue="0.60784313729999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3284 NW 26th Street Rd, Bangalore" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-J9-w3h">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3284 NW 26th Street Rd, Tampa" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-J9-w3h">
                                         <rect key="frame" x="34" y="434" width="280" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="21" id="BeM-7I-3Sz"/>

--- a/Util POC/Util POC/Base.lproj/Main.storyboard
+++ b/Util POC/Util POC/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aZe-YR-8sg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aZe-YR-8sg">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -396,7 +396,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LWA-ya-DgH">
-                                            <rect key="frame" x="147" y="34" width="83" height="32"/>
+                                            <rect key="frame" x="146" y="34" width="83" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="bg5-Ta-Wnl"/>
                                             </constraints>
@@ -994,7 +994,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4o7-p1-Dhm">
-                                                    <rect key="frame" x="147" y="33.5" width="83" height="32"/>
+                                                    <rect key="frame" x="146" y="33.5" width="83" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="B8P-Jl-IQG"/>
                                                     </constraints>
@@ -1074,7 +1074,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZcU-w9-s0p" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3860" y="-80.059970014992516"/>
+            <point key="canvasLocation" x="4810" y="-96"/>
         </scene>
         <!--Map View Controller-->
         <scene sceneID="UQb-QQ-BLA">
@@ -1498,7 +1498,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Xg3-T5-pyI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3782" y="1429"/>
+            <point key="canvasLocation" x="4204" y="1446"/>
         </scene>
         <!--REPORT AN ISSUE-->
         <scene sceneID="ddG-cx-kNt">
@@ -1846,8 +1846,12 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="88w-bV-0jm">
-                                <rect key="frame" x="151" y="513" width="72" height="30"/>
-                                <state key="normal" title="LogOut">
+                                <rect key="frame" x="137" y="513" width="100" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="100" id="Eys-y6-f0Z"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="16"/>
+                                <state key="normal" title="Logout">
                                     <color key="titleColor" red="0.98039215686274506" green="0.24313725490196078" blue="0.28627450980392155" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -2088,15 +2092,14 @@ Miami FL</string>
                             <constraint firstItem="88w-bV-0jm" firstAttribute="top" secondItem="xJa-3L-lUe" secondAttribute="bottom" constant="21" id="1E9-bX-zl1"/>
                             <constraint firstItem="xJa-3L-lUe" firstAttribute="top" secondItem="Gbj-4j-Scq" secondAttribute="bottom" constant="2" id="7xz-Q7-wkF"/>
                             <constraint firstItem="88w-bV-0jm" firstAttribute="centerX" secondItem="VDn-Dk-cl7" secondAttribute="centerX" id="DcK-KL-qIO"/>
-                            <constraint firstItem="88w-bV-0jm" firstAttribute="leading" secondItem="VDn-Dk-cl7" secondAttribute="leadingMargin" constant="135" id="E9q-OJ-pBu"/>
                             <constraint firstItem="Gbj-4j-Scq" firstAttribute="top" secondItem="1C5-Zx-rfL" secondAttribute="bottom" id="GEu-xC-WTp"/>
                             <constraint firstItem="C4b-Gg-3Rl" firstAttribute="leading" secondItem="Gbj-4j-Scq" secondAttribute="leading" id="JyJ-ea-tOS"/>
                             <constraint firstItem="Yuz-V0-H5Y" firstAttribute="leading" secondItem="VDn-Dk-cl7" secondAttribute="leadingMargin" constant="-12" id="S9e-T5-gO6"/>
                             <constraint firstItem="xJa-3L-lUe" firstAttribute="width" secondItem="Gbj-4j-Scq" secondAttribute="width" id="T10-wS-hS7"/>
                             <constraint firstAttribute="trailing" secondItem="Gbj-4j-Scq" secondAttribute="trailing" id="adc-fb-b4J"/>
                             <constraint firstItem="xJa-3L-lUe" firstAttribute="leading" secondItem="Gbj-4j-Scq" secondAttribute="leading" id="dFB-Ky-qjK"/>
+                            <constraint firstItem="GfB-Nf-U88" firstAttribute="top" secondItem="88w-bV-0jm" secondAttribute="bottom" constant="10" id="jFo-hY-dPT"/>
                             <constraint firstItem="Gbj-4j-Scq" firstAttribute="leading" secondItem="VDn-Dk-cl7" secondAttribute="leading" id="pdR-Tu-dqt"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="88w-bV-0jm" secondAttribute="trailing" constant="136" id="uSi-dh-N3u"/>
                             <constraint firstAttribute="bottom" secondItem="xJa-3L-lUe" secondAttribute="bottom" constant="111" id="xSI-jA-6ED"/>
                         </constraints>
                     </view>
@@ -2104,6 +2107,7 @@ Miami FL</string>
                         <offsetWrapper key="titlePositionAdjustment" horizontal="0.0" vertical="-15"/>
                     </tabBarItem>
                     <connections>
+                        <outlet property="logoutButton" destination="88w-bV-0jm" id="KtK-rN-CxW"/>
                         <outlet property="service1Button" destination="KcS-JD-JYd" id="wMN-S8-q7Y"/>
                         <outlet property="serviceViewDetail1HeightConstraint" destination="bnK-Uu-mOu" id="hE0-t1-fpp"/>
                     </connections>
@@ -2345,7 +2349,7 @@ Miami FL</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$170" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0gy-bu-I1g">
-                                            <rect key="frame" x="147" y="33.5" width="83" height="32"/>
+                                            <rect key="frame" x="146" y="33.5" width="83" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="32" id="aD6-nc-qhC"/>
                                             </constraints>

--- a/Util POC/Util POC/ComplaintsViewController.swift
+++ b/Util POC/Util POC/ComplaintsViewController.swift
@@ -81,7 +81,7 @@ class ComplaintsViewController: UIViewController, UINavigationControllerDelegate
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.topItem?.title = " "
         UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffsetMake(0, -60), for:UIBarMetrics.default)
-        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Complaints")
+        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Issues")
     }
     
      // MARK: - Custom

--- a/Util POC/Util POC/ComplaintsViewController.swift
+++ b/Util POC/Util POC/ComplaintsViewController.swift
@@ -81,7 +81,7 @@ class ComplaintsViewController: UIViewController, UINavigationControllerDelegate
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.topItem?.title = " "
         UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffsetMake(0, -60), for:UIBarMetrics.default)
-        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Issues")
+        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Report a New Issue")
     }
     
      // MARK: - Custom
@@ -126,7 +126,7 @@ class ComplaintsViewController: UIViewController, UINavigationControllerDelegate
     
     private func showOutageSelection() {
         // Create the AlertController and add its actions like button in ActionSheet
-        let actionSheetController = UIAlertController(title: "Please Choose", message: "Outage Type", preferredStyle: .actionSheet)
+        let actionSheetController = UIAlertController(title: "Please Choose", message: "Issue Type", preferredStyle: .actionSheet)
         
         let streetLightOutage = UIAlertAction(title: "Streetlight Outage", style: .default) { action -> Void in
             self.outageTextLabel.text = "Streetlight Outage"
@@ -236,8 +236,8 @@ class ComplaintsViewController: UIViewController, UINavigationControllerDelegate
     
     @IBAction func btnSubmitTapped(_ sender: Any) {
         
-        if self.outageTextLabel.text == "Choose Outage Type" {
-            showAlert(imageName: "safetyCautionRed", message: "Please choose outage type", buttonTitle: "Ok", completion: nil)
+        if self.outageTextLabel.text == "Choose Issue Type" {
+            showAlert(imageName: "safetyCautionRed", message: "Please choose Issue Type", buttonTitle: "Ok", completion: nil)
             return
         }
         if (self.lblAddressField.text?.isEmpty)! {

--- a/Util POC/Util POC/DetailsViewController.swift
+++ b/Util POC/Util POC/DetailsViewController.swift
@@ -13,13 +13,13 @@ class DetailsViewController: UIViewController {
     @IBOutlet weak var serviceViewDetail1HeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var service1Button: UIButton!
   
+    @IBOutlet weak var logoutButton: UIButton!
     var isView1Shown:Bool = false
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.barTintColor = .utlSunflowerYellow
-        navigationController?.navigationBar.isTranslucent = true
         // Do any additional setup after loading the view.
         
         serviceViewDetail1HeightConstraint.constant = 0.0
@@ -29,6 +29,10 @@ class DetailsViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "accountIcon", title: "Account Details")
         navigationController?.visibleViewController?.navigationItem.rightBarButtonItem = nil
+        logoutButton.layer.borderColor = UIColor.red.cgColor
+        logoutButton.layer.borderWidth = 1.0
+        logoutButton.layer.cornerRadius = 15.0
+
     }
 
 

--- a/Util POC/Util POC/LoginViewController.swift
+++ b/Util POC/Util POC/LoginViewController.swift
@@ -22,22 +22,24 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.imagePayForAnotherSelected.isHidden = true;
-        
+    
+        self.txtFieldPassword.delegate = self
         //Setting the logo of UTIL to the navigation bar
         let logo = UIImage(named: "nav-logo")
         let imageView = UIImageView(image:logo)
         imageView.contentMode = .scaleAspectFit
         self.navigationItem.titleView = imageView
         
-        //Changing the navigation bar color
-        navigationController?.navigationBar.barTintColor = UIColor.utlSlate
-        self.txtFieldPassword.delegate = self
-        
-        
         //For Removing the bottom black line in navigation bar
         //self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
         //self.navigationController?.navigationBar.shadowImage = UIImage()
 
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        //Changing the navigation bar color
+        navigationController?.navigationBar.barTintColor = UIColor.utlSlate
     }
     
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Util POC/Util POC/PayForAnotherTableViewController.swift
+++ b/Util POC/Util POC/PayForAnotherTableViewController.swift
@@ -31,7 +31,17 @@ class PayForAnotherTableViewController: UITableViewController {
         imageView.contentMode = .scaleAspectFit
         self.navigationItem.titleView = imageView
     }
-
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.tintColor = UIColor.white
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.tintColor = UIColor.utlSlate
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.

--- a/Util POC/Util POC/RecentBillsTableViewController.swift
+++ b/Util POC/Util POC/RecentBillsTableViewController.swift
@@ -15,7 +15,6 @@ class RecentBillsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.barTintColor = .utlSunflowerYellow
-        navigationController?.navigationBar.isTranslucent = true
         self.tableView.tableFooterView = UIView(frame: .zero)
         
         let billOne = Bill(billType: "Electricity Services",totalConsumption: "634 Kwh",billAmount: "$63",year:"May 2017")

--- a/Util POC/Util POC/ReportIssueViewController.swift
+++ b/Util POC/Util POC/ReportIssueViewController.swift
@@ -50,7 +50,7 @@ class ReportIssueViewController: UIViewController,UITableViewDataSource, UITable
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Complaints")
+        navigationController?.visibleViewController?.navigationItem.addNavigationView(withImage: "telemarketer", title: "Issues")
         
         let rightButtonItem = UIBarButtonItem.init(
             title: "Map",

--- a/Util POC/Util POC/ReportIssueViewController.swift
+++ b/Util POC/Util POC/ReportIssueViewController.swift
@@ -27,10 +27,10 @@ class ReportIssueViewController: UIViewController,UITableViewDataSource, UITable
         // Do any additional setup after loading the view.
     
         if (appDelegate.issue.isEmpty) {
-            let issue1 = Issue(issueType: "Streetlight Outage", dateReported: "05/05/2017", issueAddress: "3275NW 24thStreet Rd, Miami", status: "Report Submitted", lat: "25.7617", lon: "80.1918" , referenceNumber : "2356879627")
+            let issue1 = Issue(issueType: "Streetlight Outage", dateReported: "05/05/2017", issueAddress: "3275NW 24thStreet Rd, Tampa", status: "Report Submitted", lat: "25.7617", lon: "80.1918" , referenceNumber : "2356879627")
             appDelegate.issue.append(issue1)
             
-            let issue2 = Issue(issueType: "Power Outage", dateReported: "05/05/2017", issueAddress: "3275NW 24thStreet Rd, Miami", status: "Report Submitted", lat: "25.7617", lon: "80.1918" , referenceNumber : "7625467892")
+            let issue2 = Issue(issueType: "Power Outage", dateReported: "05/05/2017", issueAddress: "3275NW 24thStreet Rd, Tampa", status: "Report Submitted", lat: "25.7617", lon: "80.1918" , referenceNumber : "7625467892")
             appDelegate.issue.append(issue2)
         }
         


### PR DESCRIPTION
1. Login button
2. Navigation bar  button tint color was getting set to yellow color after log out : issue resolved
3. Pay by another navigation bar back tint color is given as white

App identifier is changed to .util

Includes below changes 

* For TECO, we should show dates on the bill details areas as MM/DD/YY (not DD/MM/YY)
Done
	
	
* I’d suggest an option for payment where you can pay either the total amount outstanding, or the total for each bill individually.  Customers should have that option
UX Change, will do after confirming

* The prices per kwh should be formatted as $0.12 (instead of 0.12$)
Done

* For addresses, please use Tampa instead of Miami for the city.  You could also use actual address for their facilities as the example addresses rather than totally fictitious streets, etc.
Now used Tampa instead of Miami, can change to original address if provided

* On the screens to report a new issue, it has “Complaints” at the top in the yellow area – this should be changed to “Issues”
Done

* When you drill into Report a New Issue, the title in yellow should change to “Report a New Issue”
Done

* The dropdown should be “Choose Issue Type” instead of “Choose Outage Type”
Done

* Under the Account Details section, the phone number should be this format: (737) 711-8796  The ( ) should already be there, so when they start typing it first fills in the 737 then moves to XXX then XXXX as entry continues

Phone number changed to (737)-711-8796 format.
Currently there is no option to type number.


* The address in Account Details should also be Tampa addresses (the example shows the address as in Miami, and Service Address in Bangalore
Added Tampa for both places
